### PR TITLE
API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy_cfg"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = ["mattico8@gmail.com", "rmarkiewicz@devolutions.net" ]
 categories = ["network-programming", "os"]

--- a/examples/get_proxies.rs
+++ b/examples/get_proxies.rs
@@ -8,11 +8,12 @@ fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
     if args.len() == 0 {
         match get_proxy_config() {
-            Ok(ProxyConfig { proxies, .. }) => {
+            Ok(Some(ProxyConfig { proxies, .. })) => {
                 for (_, p) in proxies {
                     println!("{}", p.to_string());
                 }
             },
+            Ok(None) => println!("No proxy configured"),
             Err(e) => {
                 println!("Error getting proxies: {:?}", e);
                 process::exit(1);
@@ -21,12 +22,13 @@ fn main() {
     } else {
         for arg in args {
             match get_proxy_config() {
-                Ok(proxy_config) => {
+                Ok(Some(proxy_config)) => {
                     match proxy_config.get_proxy_for_url(Url::parse(&arg).unwrap()) {
                         Some(proxy) => println!("{} : {}", arg, proxy),
                         None => println!("No proxy needed for URL: '{}'", arg),
                     }
                 },
+                Ok(None) => println!("No proxy configured"),
                 Err(e) => {
                     println!("Error getting proxies: {:?}", e);
                     process::exit(1);

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -25,7 +25,7 @@ fn get_i32_value(dictionary: &CFDictionary<CFString, CFType>, key: &'static str)
         .and_then(|v| v.to_i32())
 }
 
-pub(crate) fn get_proxy_config() -> Result<ProxyConfig> {
+pub(crate) fn get_proxy_config() -> Result<Option<ProxyConfig>> {
     let proxies_ref = unsafe {
         dynamic_store_copy_specific::SCDynamicStoreCopyProxies(ptr::null())
     };
@@ -33,7 +33,7 @@ pub(crate) fn get_proxy_config() -> Result<ProxyConfig> {
     let mut proxy_config: ProxyConfig = Default::default();
 
     if proxies_ref.is_null() {
-        return Ok(proxy_config)
+        return Ok(None)
     }
 
     let proxies: CFDictionary<CFString, CFType> = unsafe { 
@@ -80,10 +80,5 @@ pub(crate) fn get_proxy_config() -> Result<ProxyConfig> {
         proxy_config.whitelist.extend(cf_strings.iter().map(|s| s.to_string().to_lowercase()));
     }
 
-    Ok(proxy_config)
-}
-
-#[test]
-fn get_proxy_config_test() {
-    let _ = get_proxy_config();
+    Ok(Some(proxy_config))
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -192,24 +192,24 @@ fn win_http_get_default_config() -> Option<ProxyConfig> {
     Some(proxy_config)
 }
 
-pub(crate) fn get_proxy_config() -> Result<ProxyConfig> {
+pub(crate) fn get_proxy_config() -> Result<Option<ProxyConfig>> {
     let win_inet_user_proxy = win_inet_get_current_user_config();
 
     if !win_inet_is_per_user() || win_inet_user_proxy.is_none() {
         if let Some(proxy_config) = win_inet_get_local_machine_config() {
-            return Ok(proxy_config)
+            return Ok(Some(proxy_config))
         }
     }
 
     if let Some(proxy_config) = win_inet_user_proxy {
-        return Ok(proxy_config)
+        return Ok(Some(proxy_config))
     }
 
     if let Some(proxy_config) = win_http_get_default_config() {
-        return Ok(proxy_config)
+        return Ok(Some(proxy_config))
     }
 
-    Ok(Default::default())
+    Ok(None)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Update the API to return <Result<Option>, instead of just Result, to differentiate no proxy configured to an empty configuration