### PR TITLE
API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy_cfg"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 authors = ["mattico8@gmail.com", "rmarkiewicz@devolutions.net" ]
 categories = ["network-programming", "os"]

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -68,6 +68,10 @@ pub(crate) fn get_proxy_config() -> Result<Option<ProxyConfig>> {
         // TODO kSCPropNetProxiesFTPPassive
     }
 
+    if proxy_config.proxies.len() == 0 {
+        return Ok(None)
+    }
+
     if get_i32_value(&proxies, "ExcludeSimpleHostnames").unwrap_or(0) == 1 {
         proxy_config.exclude_simple = true;
     }

--- a/src/sysconfig_proxy.rs
+++ b/src/sysconfig_proxy.rs
@@ -21,6 +21,9 @@ pub(crate) fn get_proxy_config() -> Result<Option<ProxyConfig>> {
 /// argument.
 fn get_proxy_config_from_file<P: AsRef<Path>>(config_file: P) -> Result<Option<ProxyConfig>> {
     let mut proxy_config: ProxyConfig = Default::default();
+    if !config_file.as_ref().exists() {
+        return Ok(None)
+    }
     let map = read_key_value_pairs_from_file(config_file)?;
     if let Some(enabled) = map.get("PROXY_ENABLED") {
         match enabled.as_str() {


### PR DESCRIPTION
Properly return `None` for no proxy configuration in sysconfig and macOS