### PR TITLE
API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy_cfg"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2018"
 authors = ["mattico8@gmail.com", "rmarkiewicz@devolutions.net" ]
 categories = ["network-programming", "os"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,8 @@ pub struct ProxyConfig {
 }
 
 impl ProxyConfig {
-    pub fn use_proxy_for_url(&self, url: &Url) -> bool {
-        let host = match url.host_str() {
-            Some(host) => host.to_lowercase(),
-            None => return false,
-        };
+    pub fn use_proxy_for_host(&self, host: &str) -> bool {
+        let host = host.to_lowercase();
 
         if self.exclude_simple && !host.chars().any(|c| c == '.') {
             return false
@@ -58,7 +55,12 @@ impl ProxyConfig {
     }
 
     pub fn get_proxy_for_url(&self, url: &Url) -> Option<String> {
-        match self.use_proxy_for_url(url) {
+        let host = match url.host_str() {
+            Some(host) => host.to_lowercase(),
+            None => return None,
+        }; 
+
+        match self.use_proxy_for_host(&host) {
             true => self.proxies.get(url.scheme()).map(|s| s.to_string().to_lowercase()),
             false => None,
         }


### PR DESCRIPTION
Hostnames and IPs are whitelisted, not URLs